### PR TITLE
Hardware Config Reorganization

### DIFF
--- a/target.json
+++ b/target.json
@@ -18,17 +18,8 @@
     "toolchain" : "CMake/toolchain.cmake",
     "config": {
         "hardware": {
-	    "i2cCount": 2,
-            "uartCount": 2,
+	        "i2cCount": 2,
             "spiCount": 2,
-            "uartDefaults": {
-                "baudRate": 115200,
-                "wordLen": "K_WORD_LEN_8BIT",
-                "stopBits": "K_STOP_BITS_1",
-                "parity": "K_PARITY_NONE",
-                "rxQueueLen": 32,
-                "txQueueLen": 32
-            },
             "defaults": {
                 "i2c": "K_I2C2",
                 "spi": "K_SPI1"
@@ -37,11 +28,16 @@
                 "uart": "K_UART2",
                 "baudRate": 115200
             },
-            "pins": {
-                "UART1_TX": "P33",
-                "UART1_RX": "P34",
-                "UART2_TX": "P44",
-                "UART2_RX": "P45"
+            "uart": {
+                "count": 0,
+                "uart1": {
+                    "tx": "P33",
+                    "rx": "P34"
+                },
+                "uart2": {
+                    "tx": "P44",
+                    "rx": "P45"
+                }
             }
         }
     }

--- a/target.json
+++ b/target.json
@@ -29,7 +29,7 @@
                 "baudRate": 115200
             },
             "uart": {
-                "count": 0,
+                "count": 2,
                 "uart1": {
                     "tx": "P33",
                     "rx": "P34"

--- a/target.json
+++ b/target.json
@@ -18,15 +18,19 @@
     "toolchain" : "CMake/toolchain.cmake",
     "config": {
         "hardware": {
-	        "i2cCount": 2,
             "spiCount": 2,
             "defaults": {
-                "i2c": "K_I2C2",
                 "spi": "K_SPI1"
             },
             "console": {
                 "uart": "K_UART2",
                 "baudRate": 115200
+            },
+            "i2c": {
+                "count": 2,
+                "defaults": {
+                    "bus": "K_I2C2"
+                }
             },
             "uart": {
                 "count": 2,

--- a/target.json
+++ b/target.json
@@ -18,10 +18,6 @@
     "toolchain" : "CMake/toolchain.cmake",
     "config": {
         "hardware": {
-            "spiCount": 2,
-            "defaults": {
-                "spi": "K_SPI1"
-            },
             "console": {
                 "uart": "K_UART2",
                 "baudRate": 115200
@@ -30,6 +26,12 @@
                 "count": 2,
                 "defaults": {
                     "bus": "K_I2C2"
+                }
+            },
+            "spi": {
+                "count": 2,
+                "defaults": {
+                    "bus": "K_SPI1"
                 }
             },
             "uart": {


### PR DESCRIPTION
* Consolidated uart/i2c/spi configuration options (KUBOS-64), should match the new base config in target-kubos-gcc (https://github.com/openkosmosorg/target-kubos-gcc/pull/4)